### PR TITLE
Expects an array, int given

### DIFF
--- a/Classes/Module/DumperUtilTrait.php
+++ b/Classes/Module/DumperUtilTrait.php
@@ -47,7 +47,7 @@ trait DumperUtilTrait
     
     protected static function getCallee(array $args): string
     {
-        $callInfo = Kint::getCallInfo(Kint::$aliases, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), count($args));
+        $callInfo = Kint::getCallInfo(Kint::$aliases, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), $args);
         $output = '';
         
         if (isset($callInfo['callee']['file'])) {


### PR DESCRIPTION
logStream fails here because the third value should be an array, but an int is given.